### PR TITLE
Make horizon hypervisor page work.

### DIFF
--- a/.github/workflows/openstack.yaml
+++ b/.github/workflows/openstack.yaml
@@ -1,0 +1,57 @@
+name: OpenStack Nova, Horizon 
+
+on:
+  pull_request:
+    branches: [ main ]
+
+defaults:
+  run:
+    shell: bash
+    working-directory: openstack
+
+jobs:
+  test:
+
+    runs-on: self-hosted
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache images 
+        uses: actions/cache@v2
+        with:
+          path: openEuler-docker.aarch64*
+          key: ${{ runner.os }}-openeuler-docker
+
+      - name: Load base
+        run: |
+          if [ ! -f "openEuler-docker.aarch64.tar.xz" ]; then
+            wget https://repo.openeuler.org/openEuler-20.03-LTS-SP2/docker_img/aarch64/openEuler-docker.aarch64.tar.xz
+          fi
+          docker load < openEuler-docker.aarch64.tar.xz
+
+      - name: Docker build
+        run: |
+          # Build docker image
+          docker build . -t openeuler-20.03-lts-sp2:init
+
+      - name: Setup OpenStack
+        run: |
+          # Build docker image
+          docker rm -f openstack || true
+          docker run --name openstack -tid --privileged=true -p 8000:80 -h controller openeuler-20.03-lts-sp2:init
+          docker exec -t openstack /opt/run.sh
+
+      - name: Test Nova
+        run: |
+          docker exec -t openstack bash -c 'source ~/admin-openrc;/usr/bin/openstack compute service list' || exit 1
+
+      - name: Test Horizon
+        run: |
+          STATUSCODE=$(curl -m 10 -o /dev/null -s -w %{http_code} http://127.0.0.1:8000/dashboard/auth/login/)
+          if test $STATUSCODE -ne 200; then
+            echo "Horizon auth page: Failed with "$STATUSCODE"."
+            exit 1
+          else
+            echo "Horizon auth page: OK, 200."
+          fi

--- a/openstack/build.sh
+++ b/openstack/build.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Download openEuler-20.03-LTS-SP2
+if [ ! -f "openEuler-docker.aarch64.tar.xz" ]; then
+  wget https://repo.openeuler.org/openEuler-20.03-LTS-SP2/docker_img/aarch64/openEuler-docker.aarch64.tar.xz
+fi
+
+# Load docker image
+docker load < openEuler-docker.aarch64.tar.xz
+
+# Build docker image
+docker build . -t openeuler-20.03-lts-sp2:init
+
+# Run init
+docker run --name openstack -tid --privileged=true -p 8000:80 -h controller openeuler-20.03-lts-sp2:init
+
+# Exec openstack setup script
+docker exec -ti openstack /opt/run.sh
+
+# Test for horizon
+STATUSCODE=$(curl -m 10 -o /dev/null -s -w %{http_code} http://127.0.0.1:8000/dashboard/auth/login/)
+if test $STATUSCODE -ne 200; then
+  echo "Horizon auth page: Failed with "$STATUSCODE"."
+else
+  echo "Horizon auth page: OK, 200."
+fi

--- a/openstack/conf/OpenStack_Queens.repo
+++ b/openstack/conf/OpenStack_Queens.repo
@@ -1,0 +1,5 @@
+[openstack_queens]
+name=OpenStack_Queens
+baseurl=https://repo.oepkgs.net/openEuler/rpm/openEuler-20.03-LTS-SP2/budding-openeuler/openstack/queens/aarch64/
+gpgcheck=0
+enabled=1

--- a/openstack/conf/admin-openrc
+++ b/openstack/conf/admin-openrc
@@ -1,0 +1,8 @@
+export OS_PROJECT_DOMAIN_NAME=Default
+export OS_USER_DOMAIN_NAME=Default
+export OS_PROJECT_NAME=admin
+export OS_USERNAME=admin
+export OS_PASSWORD=ADMIN_PASS
+export OS_AUTH_URL=http://controller:5000/v3
+export OS_IDENTITY_API_VERSION=3
+export OS_IMAGE_API_VERSION=2

--- a/openstack/conf/keystone.conf
+++ b/openstack/conf/keystone.conf
@@ -1,0 +1,4 @@
+[database]
+connection = mysql+pymysql://keystone:KEYSTONE_DBPASS@controller/keystone
+[token]
+provider = fernet

--- a/openstack/conf/nova.conf
+++ b/openstack/conf/nova.conf
@@ -1,0 +1,68 @@
+[DEFAULT]
+enabled_apis = osapi_compute,metadata
+transport_url = rabbit://openstack:RABBIT_PASS@controller:5672/
+my_ip = 127.0.0.1
+use_neutron = true
+firewall_driver = nova.virt.firewall.NoopFirewallDriver
+compute_driver=libvirt.LibvirtDriver
+instances_path = /var/lib/nova/instances/
+lock_path = /var/lib/nova/tmp
+
+[api_database]
+connection = mysql+pymysql://nova:NOVA_DBPASS@controller/nova_api
+
+[database]
+connection = mysql+pymysql://nova:NOVA_DBPASS@controller/nova
+
+[api]
+auth_strategy = keystone
+
+[keystone_authtoken]
+www_authenticate_uri = http://controller:5000/
+auth_url = http://controller:5000/
+memcached_servers = controller:11211
+auth_type = password
+project_domain_name = Default
+user_domain_name = Default
+project_name = service
+username = nova
+password = NOVA_PASS
+
+[vnc]
+enabled = true
+server_listen = $my_ip
+server_proxyclient_address = $my_ip
+novncproxy_base_url = http://controller:6080/vnc_auto.html
+
+[libvirt]
+virt_type = qemu
+cpu_mode = custom
+cpu_model = cortex-a72
+
+[glance]
+api_servers = http://controller:9292
+
+[oslo_concurrency]
+lock_path = /var/lib/nova/tmp
+
+[placement]
+region_name = RegionOne
+project_domain_name = Default
+project_name = service
+auth_type = password
+user_domain_name = Default
+auth_url = http://controller:5000/v3
+username = placement
+password = PLACEMENT_PASS
+
+[neutron]
+auth_url = http://controller:5000
+auth_type = password
+project_domain_name = default
+user_domain_name = default
+region_name = RegionOne
+project_name = service
+username = neutron
+password = NEUTRON_PASS
+service_metadata_proxy = true
+metadata_proxy_shared_secret = METADATA_SECRET

--- a/openstack/conf/openstack.cnf
+++ b/openstack/conf/openstack.cnf
@@ -1,0 +1,7 @@
+[mysqld]
+bind-address = 127.0.0.1
+default-storage-engine = innodb
+innodb_file_per_table = on
+max_connections = 4096
+collation-server = utf8_general_ci
+character-set-server = utf8

--- a/openstack/dockerfile
+++ b/openstack/dockerfile
@@ -1,0 +1,43 @@
+FROM openeuler-20.03-lts-sp2:latest
+
+
+# Install systemd init
+RUN yum install -y systemd vim
+
+# Add oepkg as 3rd yum repo
+COPY conf/OpenStack_Queens.repo /etc/yum.repos.d/
+RUN yum clean all && yum makecache
+
+# The conroller has been set by `docker run -h controller`
+RUN echo "127.0.0.1   controller" >> /etc/hosts
+
+# Install mysql
+RUN yum install mariadb mariadb-server python-PyMySQL -y
+
+# Configure mysql
+COPY conf/openstack.cnf /etc/my.cnf.d/
+
+# Install RabbitMQ
+RUN yum install rabbitmq-server -y
+
+# Install keystone
+RUN yum install openstack-keystone httpd mod_wsgi python2-mod_wsgi -y
+COPY conf/keystone.conf /etc/keystone/keystone.conf
+# Httpd config
+RUN echo "ServerName controller" >> /etc/httpd/conf/httpd.conf
+RUN ln -s /usr/share/keystone/wsgi-keystone.conf /etc/httpd/conf.d/
+RUN yum install python2-openstackclient -y
+
+COPY conf/admin-openrc /root/
+
+# Install openstack-dashboard
+RUN yum install openstack-dashboard -y
+
+# Install Nova
+RUN yum install openstack-nova-api openstack-nova-conductor openstack-nova-compute -y
+COPY conf/nova.conf /etc/nova/
+
+COPY run.sh /opt/
+RUN chmod +x /opt/run.sh
+
+CMD ["/usr/sbin/init"]

--- a/openstack/run.sh
+++ b/openstack/run.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -ex
+
+# reset controller in /etc/hosts
+echo "$(sed 's/[0-9\.]\+[\t  ]\+controller/127.0.0.1 controller/g' /etc/hosts)" > /etc/hosts
+
+# mysql
+systemctl enable mariadb.service
+systemctl start mariadb.service
+
+# rabbitmq
+systemctl enable rabbitmq-server.service
+systemctl start rabbitmq-server.service
+rabbitmqctl add_user openstack RABBIT_PASS
+rabbitmqctl set_permissions openstack ".*" ".*" ".*"
+
+# horizon
+sed -i "s/ALLOWED_HOSTS.*/ALLOWED_HOSTS = ['*', ]/g" /etc/openstack-dashboard/local_settings
+sed -i "s/OPENSTACK_HOST.*/OPENSTACK_HOST = 'controller'/g" /etc/openstack-dashboard/local_settings
+sed -i "s/OPENSTACK_KEYSTONE_URL.*/OPENSTACK_KEYSTONE_URL = 'http:\/\/%s:5000\/v3' % OPENSTACK_HOST/g" /etc/openstack-dashboard/local_settings
+
+# Keystone
+mysql -u root --password='' -e "CREATE DATABASE keystone;"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'localhost' IDENTIFIED BY 'KEYSTONE_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON keystone.* TO 'keystone'@'%' IDENTIFIED BY 'KEYSTONE_DBPASS';"
+
+su -s /bin/sh -c "keystone-manage db_sync" keystone
+
+keystone-manage fernet_setup --keystone-user keystone --keystone-group keystone
+keystone-manage credential_setup --keystone-user keystone --keystone-group keystone
+
+keystone-manage bootstrap --bootstrap-password ADMIN_PASS \
+--bootstrap-admin-url http://controller:5000/v3/ \
+--bootstrap-internal-url http://controller:5000/v3/ \
+--bootstrap-public-url http://controller:5000/v3/ \
+--bootstrap-region-id RegionOne
+
+systemctl enable httpd.service
+systemctl start httpd.service
+
+source /root/admin-openrc
+openstack domain create --description "An Example Domain" example
+openstack project create --domain default --description "Service Project" service
+openstack project create --domain default --description "Demo Project" myproject
+
+# Nova
+mysql -u root --password='' -e "CREATE DATABASE nova_api;CREATE DATABASE nova;CREATE DATABASE nova_cell0;"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova_api.* TO 'nova'@'localhost' IDENTIFIED BY 'NOVA_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova_api.* TO 'nova'@'%' IDENTIFIED BY 'NOVA_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova.* TO 'nova'@'localhost' IDENTIFIED BY 'NOVA_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova.* TO 'nova'@'%' IDENTIFIED BY 'NOVA_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'localhost' IDENTIFIED BY 'NOVA_DBPASS';"
+mysql -u root --password='' -e "GRANT ALL PRIVILEGES ON nova_cell0.* TO 'nova'@'%' IDENTIFIED BY 'NOVA_DBPASS';"
+
+openstack user create --domain default --password NOVA_PASS nova
+openstack role add --project service --user nova admin
+openstack service create --name nova --description "OpenStack Compute" compute
+
+openstack endpoint create --region RegionOne compute public http://controller:8774/v2.1
+openstack endpoint create --region RegionOne compute internal http://controller:8774/v2.1
+openstack endpoint create --region RegionOne compute admin http://controller:8774/v2.1
+
+su -s /bin/sh -c "nova-manage api_db sync" nova
+su -s /bin/sh -c "nova-manage cell_v2 map_cell0" nova
+su -s /bin/sh -c "nova-manage cell_v2 create_cell --name=cell1 --verbose" nova
+su -s /bin/sh -c "nova-manage db sync" nova
+su -s /bin/sh -c "nova-manage cell_v2 list_cells" nova
+su -s /bin/sh -c "nova-manage cell_v2 discover_hosts --verbose" nova
+
+systemctl enable openstack-nova-api.service openstack-nova-conductor.service libvirtd.service openstack-nova-compute.service
+systemctl start openstack-nova-api.service openstack-nova-conductor.service libvirtd.service openstack-nova-compute.service


### PR DESCRIPTION
# Feature
- Build a base image with openstack installation.(mariadb/rabbitmq/keystone/nova)
- Run docker using /usr/sbin/init to make sure permission for systemd/systemctl.
- Setup mariadb/rabbitmq/keystone/nova.
- Add OpenStack nova/horizon docker build, docker run, service check end to end test on github action

# Usage
You could use below script to startup Horizon dashboard with Nova Hypervisor query support
```shell
cd openstack
sh build.sh
```

# Preview
Then browser the `https://HOST_IP:8000:dashboard/` you can see your cute horizon.

![image](https://user-images.githubusercontent.com/1736354/125911585-c35c6ea6-88ef-4b0a-986c-004c4e5bc65c.png)

# CI test results:
![image](https://user-images.githubusercontent.com/1736354/125925910-035c3826-0fd9-44fa-91a3-71b43a2744d6.png)
